### PR TITLE
fix: correct column order in PacketChainerForm table model

### DIFF
--- a/app/src/main/java/de/fiereu/ppe/forms/PacketChainerForm.java
+++ b/app/src/main/java/de/fiereu/ppe/forms/PacketChainerForm.java
@@ -266,7 +266,7 @@ public class PacketChainerForm extends JFrame {
                     packet.data.saveToStream(outputStream);
                     data = outputStream.toByteArray();
                 }
-                tableModel.addRow(new Object[]{packet.label, packet.delay, data});
+                tableModel.addRow(new Object[]{packet.label, packet.id, packet.delay, data});
             }
             JOptionPane.showMessageDialog(this, "Packets loaded from packets.json.", "Success",
                     JOptionPane.INFORMATION_MESSAGE);


### PR DESCRIPTION
the id field was missing, causing data to be loaded into incorrect columns.