### PR TITLE
feat(agent,app): add region-based DNS redirection

### DIFF
--- a/agent/src/main/java/de/fiereu/ppe/agent/DnsPatch.java
+++ b/agent/src/main/java/de/fiereu/ppe/agent/DnsPatch.java
@@ -1,0 +1,46 @@
+package de.fiereu.ppe.agent;
+
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+
+public class DnsPatch extends ClassVisitor {
+
+  private static final String DNS_REDIRECTS_OWNER = "de/fiereu/ppe/pokemmo/DnsRedirects";
+  private static final String DNS_REDIRECTS_METHOD = "redirect";
+  private static final String DNS_REDIRECTS_DESC = "(Ljava/lang/String;)Ljava/lang/String;";
+
+  DnsPatch(int api, ClassVisitor classVisitor) {
+    super(api, classVisitor);
+  }
+
+  @Override
+  public MethodVisitor visitMethod(int access, String name, String descriptor, String signature,
+      String[] exceptions) {
+    return new MethodVisitor(api,
+        super.visitMethod(access, name, descriptor, signature, exceptions)) {
+      @Override
+      public void visitMethodInsn(int opcode, String owner, String mName, String mDescriptor,
+          boolean isInterface) {
+        if (owner.equals("java/net/InetAddress")
+            && mName.equals("getByName")
+            && mDescriptor.equals("(Ljava/lang/String;)Ljava/net/InetAddress;")) {
+          super.visitMethodInsn(Opcodes.INVOKESTATIC,
+              DNS_REDIRECTS_OWNER,
+              DNS_REDIRECTS_METHOD,
+              DNS_REDIRECTS_DESC,
+              false);
+        } else if (owner.equals("java/net/InetAddress")
+            && mName.equals("getAllByName")
+            && mDescriptor.equals("(Ljava/lang/String;)[Ljava/net/InetAddress;")) {
+          super.visitMethodInsn(Opcodes.INVOKESTATIC,
+              DNS_REDIRECTS_OWNER,
+              DNS_REDIRECTS_METHOD,
+              DNS_REDIRECTS_DESC,
+              false);
+        }
+        super.visitMethodInsn(opcode, owner, mName, mDescriptor, isInterface);
+      }
+    };
+  }
+}

--- a/agent/src/main/java/de/fiereu/ppe/agent/PpeClassFileTransformer.java
+++ b/agent/src/main/java/de/fiereu/ppe/agent/PpeClassFileTransformer.java
@@ -12,11 +12,19 @@ public class PpeClassFileTransformer implements ClassFileTransformer {
   @Override
   public byte[] transform(ClassLoader loader, String className, Class<?> classBeingRedefined,
       ProtectionDomain protectionDomain, byte[] classfileBuffer) {
+    if (className == null
+        || className.startsWith("java/")
+        || className.startsWith("javax/")
+        || className.startsWith("sun/")
+        || className.startsWith("de/fiereu/ppe/")) {
+      return null;
+    }
     try {
       ClassReader classReader = new ClassReader(classfileBuffer);
       ClassWriter classWriter = new ClassWriter(classReader, 0);
-      ClassVisitor classVisitor = new CertificatePatch(Opcodes.ASM9, classWriter);
-      classReader.accept(classVisitor, 0);
+      ClassVisitor certPatch = new CertificatePatch(Opcodes.ASM9, classWriter);
+      ClassVisitor dnsPatch = new DnsPatch(Opcodes.ASM9, certPatch);
+      classReader.accept(dnsPatch, 0);
       return classWriter.toByteArray();
     } catch (Exception e) {
       e.printStackTrace();

--- a/app/src/main/java/de/fiereu/ppe/forms/MainForm.java
+++ b/app/src/main/java/de/fiereu/ppe/forms/MainForm.java
@@ -2,25 +2,22 @@ package de.fiereu.ppe.forms;
 
 import de.fiereu.ppe.ErrorHandler;
 import de.fiereu.ppe.PacketHistory;
+import de.fiereu.ppe.pokemmo.Region;
 import de.fiereu.ppe.proxy.ServerType;
 import de.fiereu.ppe.util.Finder;
-
 import de.fiereu.ppe.util.Platform;
-import org.apache.commons.configuration2.Configuration;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import javax.swing.*;
-
-
+import java.awt.BorderLayout;
 import java.awt.event.ActionEvent;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
-import java.awt.BorderLayout;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import javax.swing.*;
+import org.apache.commons.configuration2.Configuration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class MainForm extends JFrame {
 
@@ -116,10 +113,12 @@ public class MainForm extends JFrame {
     private void runPokeMMO(ActionEvent e) {
         try {
             String pokeMMOPath = getFilePath("pokeMMO.path", Finder::findPokeMMO, "PokeMMO not found");
-            if (pokeMMOPath == null) return;
+            if (pokeMMOPath == null)
+                return;
 
             String agentPath = getFilePath("pokeMMO.agent", Finder::findAgent, "Agent not found");
-            if (agentPath == null) return;
+            if (agentPath == null)
+                return;
 
             List<String> command = new ArrayList<>();
             Platform platform = Platform.get();
@@ -137,7 +136,7 @@ public class MainForm extends JFrame {
             }
 
             new ProcessBuilder(command)
-                    .directory(resolveWorkingDir(pokeMMOPath, platform))
+                    .directory(resolveWorkingDir(pokeMMOPath))
                     .start();
         } catch (IOException ex) {
             log.error("Failed to start PokeMMO", ex);
@@ -148,33 +147,39 @@ public class MainForm extends JFrame {
     }
 
     private List<String> buildJavaCommand(String pokeMMOPath, String agentPath, Platform platform) {
-        String classPath = resolveClassPath(pokeMMOPath, platform);
+        String classPath = resolveClassPath(pokeMMOPath);
         List<String> cmd = new ArrayList<>();
         cmd.add("java");
         cmd.add("-javaagent:" + agentPath);
         if (platform == Platform.MAC) {
             cmd.add("-XstartOnFirstThread");
         }
+        cmd.add("-Dppe.dns.region=" + serverController.getRegion().name().toLowerCase());
+        if (serverController.getRegion() == Region.CUSTOM) {
+            cmd.add("-Dppe.dns.custom.hostname=" + serverController.getCustomHostname());
+        }
         cmd.addAll(List.of("-Xms128M", "-Xmx256M", "-Dfile.encoding=UTF-8"));
         cmd.addAll(List.of("-cp", classPath, "com.pokeemu.client.Client"));
         return cmd;
     }
 
-    private String resolveClassPath(String pokeMMOPath, Platform platform) {
+    private String resolveClassPath(String pokeMMOPath) {
         if (pokeMMOPath.endsWith(".jar")) {
             return pokeMMOPath;
         }
         File f = new File(pokeMMOPath);
         if (f.isDirectory()) {
             File jar = new File(pokeMMOPath, "PokeMMO.exe");
-            if (jar.exists()) return jar.getAbsolutePath();
+            if (jar.exists())
+                return jar.getAbsolutePath();
         }
         return pokeMMOPath;
     }
 
-    private File resolveWorkingDir(String pokeMMOPath, Platform platform) {
+    private File resolveWorkingDir(String pokeMMOPath) {
         File f = new File(pokeMMOPath);
-        if (f.isDirectory()) return f;
+        if (f.isDirectory())
+            return f;
         return f.getParentFile();
     }
 

--- a/app/src/main/java/de/fiereu/ppe/forms/ServerControlPane.java
+++ b/app/src/main/java/de/fiereu/ppe/forms/ServerControlPane.java
@@ -13,6 +13,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import javax.swing.JButton;
+import javax.swing.JComboBox;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
@@ -23,6 +24,7 @@ import com.github.maltalex.ineter.base.IPAddress;
 
 import de.fiereu.ppe.ErrorHandler;
 import de.fiereu.ppe.PacketHistory;
+import de.fiereu.ppe.pokemmo.Region;
 import de.fiereu.ppe.proxy.ProxyClient;
 import de.fiereu.ppe.proxy.ProxyServer;
 import de.fiereu.ppe.proxy.ServerType;
@@ -34,7 +36,8 @@ public class ServerControlPane extends JPanel implements Closeable {
   private final Set<ProxyServer> servers = new HashSet<>();
   private JTextField proxyIPTF;
   private JTextField proxyIP6TF;
-  private JTextField lsIPTF;
+  private JComboBox<Region> regionCombo;
+  private JTextField customHostnameTF;
   private JTextField lsPortTF;
   private JTextField gsPortTF;
   private JTextField csPortTF;
@@ -119,11 +122,30 @@ public class ServerControlPane extends JPanel implements Closeable {
     };
   }
 
+  public Region getRegion() {
+    return (Region) regionCombo.getSelectedItem();
+  }
+
+  public String getCustomHostname() {
+    return customHostnameTF.getText().trim();
+  }
+
   private void startServerBtn(ActionEvent e) {
     try {
       var proxyIP = getProxyIP();
       var proxyIP6 = getProxyIP6();
-      var lsIP = IPAddress.of(InetAddress.getByName(lsIPTF.getText()));
+      Region region = getRegion();
+      String targetHost;
+      if (region == Region.CUSTOM) {
+        targetHost = getCustomHostname();
+        if (targetHost.isBlank()) {
+          ErrorHandler.handle(this, "Custom hostname is empty.", null);
+          return;
+        }
+      } else {
+        targetHost = region.realIp;
+      }
+      var lsIP = IPAddress.of(InetAddress.getByName(targetHost));
       var lsPort = getProxyPort(ServerType.LOGIN);
       startServer(
           ServerType.LOGIN,
@@ -162,8 +184,10 @@ public class ServerControlPane extends JPanel implements Closeable {
     proxyIPTF = new JTextField();
     JLabel label3 = new JLabel();
     proxyIP6TF = new JTextField();
-    JLabel label2 = new JLabel();
-    lsIPTF = new JTextField();
+    JLabel regionLbl = new JLabel();
+    regionCombo = new JComboBox<>(Region.values());
+    JLabel customHostnameLbl = new JLabel();
+    customHostnameTF = new JTextField();
     JLabel lsPortLbl = new JLabel();
     lsPortTF = new JTextField();
     JLabel gsPortLbl = new JLabel();
@@ -187,6 +211,8 @@ public class ServerControlPane extends JPanel implements Closeable {
             "[]" +
             "[]" +
             "[]" +
+            "[]" +
+            "[]" +
             "[grow]"));
 
     label1.setText("Proxy IP:");
@@ -199,45 +225,54 @@ public class ServerControlPane extends JPanel implements Closeable {
     add(label3, "cell 0 1");
 
     proxyIP6TF.setText("::1");
-    add(proxyIP6TF, "width 200");
+    add(proxyIP6TF, "cell 1 1,width 200");
 
-    label2.setText("Login server IP:");
-    add(label2, "cell 0 2");
+    regionLbl.setText("Region:");
+    add(regionLbl, "cell 0 2");
 
-    lsIPTF.setText("loginserver.pokemmo.eu");
-    add(lsIPTF, "cell 1 2,width 200");
+    regionCombo.setSelectedItem(Region.EU);
+    regionCombo.addActionListener(e -> {
+      boolean isCustom = regionCombo.getSelectedItem() == Region.CUSTOM;
+      customHostnameTF.setEnabled(isCustom);
+    });
+    add(regionCombo, "cell 1 2,width 200");
+
+    customHostnameLbl.setText("Custom hostname:");
+    add(customHostnameLbl, "cell 0 3");
+
+    customHostnameTF.setEnabled(false);
+    add(customHostnameTF, "cell 1 3,width 200");
 
     lsPortLbl.setText("Login server Port:");
-    add(lsPortLbl, "cell 0 3");
+    add(lsPortLbl, "cell 0 4");
 
     lsPortTF.setText("2106");
-    add(lsPortTF, "cell 1 3");
+    add(lsPortTF, "cell 1 4");
 
     gsPortLbl.setText("Game server Port:");
-    add(gsPortLbl, "cell 0 4");
+    add(gsPortLbl, "cell 0 5");
 
     gsPortTF.setText("7777");
-    add(gsPortTF, "cell 1 4");
+    add(gsPortTF, "cell 1 5");
 
     csPortLbl.setText("Chat server Port:");
-    add(csPortLbl, "cell 0 5");
+    add(csPortLbl, "cell 0 6");
 
     csPortTF.setText("7778");
-    add(csPortTF, "cell 1 5");
+    add(csPortTF, "cell 1 6");
 
     startServerBtn.setText("Start Server");
     startServerBtn.addActionListener(this::startServerBtn);
-    add(startServerBtn, "cell 0 6 2 1,growx");
+    add(startServerBtn, "cell 0 7 2 1,growx");
 
     stopServerBtn.setText("Stop Server");
     stopServerBtn.setEnabled(false);
     stopServerBtn.addActionListener(this::stopServerBtn);
-    add(stopServerBtn, "cell 0 7 2 1,growx");
+    add(stopServerBtn, "cell 0 8 2 1,growx");
 
     serverLog.setWrapStyleWord(true);
     serverLog.setLineWrap(true);
     scrollPane1.setViewportView(serverLog);
-    add(scrollPane1, "cell 0 8 2 1,grow");
-
+    add(scrollPane1, "cell 0 9 2 1,grow");
   }
 }

--- a/certs/src/main/java/de/fiereu/ppe/pokemmo/DnsRedirects.java
+++ b/certs/src/main/java/de/fiereu/ppe/pokemmo/DnsRedirects.java
@@ -1,0 +1,55 @@
+package de.fiereu.ppe.pokemmo;
+
+import java.util.Collections;
+import java.util.Map;
+
+public final class DnsRedirects {
+
+  private static final String PROP_REGION = "ppe.dns.region";
+  private static final String PROP_CUSTOM_HOSTNAME = "ppe.dns.custom.hostname";
+
+  private DnsRedirects() {}
+
+  public static Region getRegion() {
+    String regionStr = System.getProperty(PROP_REGION);
+    if (regionStr != null) {
+      try {
+        return Region.valueOf(regionStr.toUpperCase());
+      } catch (IllegalArgumentException ignored) {
+      }
+    }
+    return Region.EU;
+  }
+
+  public static String getCustomHostname() {
+    return System.getProperty(PROP_CUSTOM_HOSTNAME);
+  }
+
+  public static Map<String, String> getRedirects() {
+    Region region = getRegion();
+    if (region == Region.CUSTOM) {
+      String custom = getCustomHostname();
+      if (custom != null && !custom.isBlank()) {
+        return Map.of(custom.toLowerCase(), "127.0.0.1");
+      }
+      return Collections.emptyMap();
+    }
+    return Map.of(region.hostname.toLowerCase(), "127.0.0.1");
+  }
+
+  public static String redirect(String hostname) {
+    if (hostname == null) {
+      return null;
+    }
+    return getRedirects().getOrDefault(hostname.toLowerCase(), hostname);
+  }
+
+  public static String getTargetIp() {
+    Region region = getRegion();
+    if (region == Region.CUSTOM) {
+      String custom = getCustomHostname();
+      return custom != null && !custom.isBlank() ? custom : null;
+    }
+    return region.realIp;
+  }
+}

--- a/certs/src/main/java/de/fiereu/ppe/pokemmo/Region.java
+++ b/certs/src/main/java/de/fiereu/ppe/pokemmo/Region.java
@@ -1,0 +1,23 @@
+package de.fiereu.ppe.pokemmo;
+
+public enum Region {
+  EU("loginserver.pokemmo.eu", "185.152.67.99"),
+  GLOBAL("loginserver.pokemmo.com", "185.180.13.145"),
+  CUSTOM(null, null);
+
+  public final String hostname;
+  public final String realIp;
+
+  Region(String hostname, String realIp) {
+    this.hostname = hostname;
+    this.realIp = realIp;
+  }
+
+  @Override
+  public String toString() {
+    if (this == CUSTOM) {
+      return "CUSTOM";
+    }
+    return name() + " [" + hostname + "]";
+  }
+}


### PR DESCRIPTION
A quick fix for issues like #4 which does away with the need for manual `/etc/hosts` edits through bytecode DNS redirection. Tested on the global server (`loginserver.pokemmo.com`) on macOS.

- implements new `Region` type mapping region codes to FQDN and real IPs
  - hardcoded IP targets for now (could be dynamic but fine for now)
  - supports custom hosts w/ `Region.CUSTOM`
- patches `java.net.InetAddress.(getByName|getAllByName)`
  - redirects selected `Region` type to alternative IP
  - skips known non-PokeMMO classes
- adjust forms slightly to use `Region` field as input
- makes edits to `/etc/hosts` or equivalent no longer required for proxy functionality

Relies or PR #5, so please approve that one so this one diffs cleaner as well :p

If you have any suggestions, please let me know.